### PR TITLE
Change action that is run to remove the default admin bar padding

### DIFF
--- a/minimize-admin-bar.php
+++ b/minimize-admin-bar.php
@@ -35,4 +35,4 @@ add_action('wp_head', 'mab_remove_padding',1);
 function mab_add_admin_bar_toggle() {
   echo '<a href="javascript:void();" id="mab-btn-show-admin-bar" title="Show WP Admin Bar"></a>';
 }
-add_action('admin_bar_init', 'mab_add_admin_bar_toggle');
+add_action('wp_footer', 'mab_add_admin_bar_toggle');

--- a/minimize-admin-bar.php
+++ b/minimize-admin-bar.php
@@ -27,7 +27,7 @@ add_action('wp_enqueue_scripts', 'mab_toggle_admin_bar_assets');
 function mab_remove_padding() {
   remove_action('wp_head', '_admin_bar_bump_cb');
 }
-add_action('get_header', 'mab_remove_padding');
+add_action('wp_head', 'mab_remove_padding',1);
 
 //------------------------------------------------------------------------------
 // Add the WP Admin Bar toggle


### PR DESCRIPTION
Great idea/plugin! Fired it up on a small, one page website and the html 32px padding was still there so I went digging.

The ‘get_header’ action (which remove the 32px of padding the WP Admin Bar adds) is only called if loading a header.php file which doesn’t always happen, e.g. with single page websites. The ’wp_head’ action is called in wp_head() which, like wp_footer() is always called.

Thanks! Looking forward to using this on more sites.