### PR TITLE
Do not load CSS/JS when not needed

### DIFF
--- a/minimize-admin-bar.php
+++ b/minimize-admin-bar.php
@@ -4,22 +4,36 @@ defined( 'ABSPATH' ) or die ('No direct access to files');
 /**
  * Plugin Name: Minimize WP Admin Bar
  * Plugin URI: http://mikeeverhart.net
- * Description: Minimizes the WP Admin Bar, making it less obnoxious 
+ * Description: Minimizes the WP Admin Bar, making it less obnoxious
  * Version: 0.1a
  * Author: Mike Everhart
  * Author URI: http://mikeeverhart.net
  * License: GPL2
  */
 
+//------------------------------------------------------------------------------
+// Do not inject CSS/JS on the front-end if the user is not logged in and the bar isn't present on the page
+// Init done after plugin_loaded because is_admin_bar_showing() uses is_user_logged_in() which is a pluggable function.
+//------------------------------------------------------------------------------
+add_action("plugins_loaded", "mab_init_plugin");
+
+function mab_init_plugin(){
+  if( is_admin_bar_showing() ){
+    add_action('wp_enqueue_scripts', 'mab_toggle_admin_bar_assets');
+    add_action('wp_head', 'mab_remove_padding', 1);
+   }
+
+   add_action('wp_after_admin_bar_render', 'mab_add_admin_bar_toggle');
+
+}
 
 //------------------------------------------------------------------------------
-// Enqueue the CSS and JS 
+// Enqueue the CSS and JS
 //------------------------------------------------------------------------------
 function mab_toggle_admin_bar_assets() {
     wp_enqueue_style( 'mab-minimize-admin-bar-css', plugin_dir_url( __FILE__ ) . 'css/style.css');
     wp_enqueue_script( 'mab-minimize-admin-bar-js', plugin_dir_url( __FILE__ ) . 'js/app.js', array( 'jquery' ), '1.0', true );
 }
-add_action('wp_enqueue_scripts', 'mab_toggle_admin_bar_assets');
 
 //------------------------------------------------------------------------------
 // Remove the 32px of padding the WP Admin Bar adds
@@ -27,7 +41,6 @@ add_action('wp_enqueue_scripts', 'mab_toggle_admin_bar_assets');
 function mab_remove_padding() {
   remove_action('wp_head', '_admin_bar_bump_cb');
 }
-add_action('wp_head', 'mab_remove_padding', 1);
 
 //------------------------------------------------------------------------------
 // Add the WP Admin Bar toggle
@@ -35,4 +48,3 @@ add_action('wp_head', 'mab_remove_padding', 1);
 function mab_add_admin_bar_toggle() {
     echo '<a href="javascript:void();" id="mab-btn-show-admin-bar" title="Show WP Admin Bar"></a>';
 }
-add_action('wp_after_admin_bar_render', 'mab_add_admin_bar_toggle');


### PR DESCRIPTION
This plugin always loads the `css/style.css` and `js/app.js` on the website's front-end, even when the menu bar is not present or when a user is not logged in.

This PR uses [`is_admin_bar_showing()`](https://developer.wordpress.org/reference/functions/is_user_logged_in/) to make sure these two files are loaded when the menu bar is being displayed.
